### PR TITLE
Add support of pkg-errors specific functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,27 +103,16 @@ The following syntax is supported.
 | `errors.New("MESSAGE")` | `New("MESSAGE")` | `New("MESSAGE")` |
 | `fmt.Errorf("FORMAT", ...)` | `Errorf("FORMAT", ...)` | `Errorf("FORMAT", ...)` |
 | `fmt.Errorf("FORMAT: %w", ..., err)` | `Errorf("FORMAT: %w", ..., err)` | `Wrapf(err, "FORMAT", ...)` |
-| `errors.Unwrap(err)` | `Unwrap(err)` | `Cause(err)` <sup>1</sup> |
+| `errors.Unwrap(err)` | `Unwrap(err)` | `Cause(err)` |
 | `errors.As(err, v)` | `As(err, v)` | - |
 | `errors.Is(err, v)` | `Is(err, v)` | - |
-| - | - | `Wrap(err, "MESSAGE")` <sup>2</sup> |
-| - | - | `WithStack(err)` <sup>2</sup> |
-| - | - | `WithMessage("MESSAGE", err)` <sup>2</sup> |
+| `fmt.Errorf("%s: %w", "MESSAGE", err)` | `Errorf("%s: %w", "MESSAGE", err)` | `Wrap(err, "MESSAGE")` <sup>1</sup> |
+| `fmt.Errorf("%w", err)` | `Errorf("%w", err)` | `WithStack(err)` <sup>1</sup> |
+| `fmt.Errorf("%s: %s", "MESSAGE", err)` | `Errorf("%s: %s", "MESSAGE", err)` | `WithMessage(err, "MESSAGE")` <sup>1</sup> |
+| `fmt.Errorf("FORMAT: %s", ..., err)` | `Errorf("FORMAT: %s", ..., err)` | `WithMessagef(err, "FORMAT", ...)` <sup>1</sup> |
 
-<sup>1</sup> Incompatible behavior. You may need to rewrite code manually.
-
-<sup>2</sup> Not supported yet.
-
-
-### NOTE: these are not implemented yet
-
-Functions:
-
-- `golang.org/x/xerrors.Opaque()`
-- `github.com/pkg/errors.Wrap()`
-- `github.com/pkg/errors.WithStack()`
-- `github.com/pkg/errors.WithMessage()`
-- `github.com/pkg/errors.WithMessagef()`
+<sup>1</sup> Only rewrite from pkg-errors to go-errors or xerrors is supported.
+Opposite rewrite is not supported.
 
 
 ### Dump command

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/google/go-cmp v0.4.0
-	github.com/pkg/errors v0.8.0
+	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v0.0.6
 	github.com/spf13/pflag v1.0.5
 	golang.org/x/tools v0.0.0-20190903163617-be0da057c5e3

--- a/go.sum
+++ b/go.sum
@@ -66,6 +66,8 @@ github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=

--- a/pkg/rewrite/rewrite_test.go
+++ b/pkg/rewrite/rewrite_test.go
@@ -64,6 +64,19 @@ func TestDo(t *testing.T) {
 			testRewrite(t, ctx, rewrite.GoErrors, "testdata/full/xerrors/main.go", "testdata/full/goerrors/main.go")
 		})
 	})
+
+	t.Run("pkg-errors specific functions", func(t *testing.T) {
+		t.Run("pkg-errors to xerrors", func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(ctx, time.Second)
+			defer cancel()
+			testRewrite(t, ctx, rewrite.Xerrors, "testdata/pkgerrors_specific/pkgerrors/main.go", "testdata/pkgerrors_specific/xerrors/main.go")
+		})
+		t.Run("pkg-errors to go-errors", func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(ctx, time.Second)
+			defer cancel()
+			testRewrite(t, ctx, rewrite.GoErrors, "testdata/pkgerrors_specific/pkgerrors/main.go", "testdata/pkgerrors_specific/goerrors/main.go")
+		})
+	})
 }
 
 func testRewrite(t *testing.T, ctx context.Context, target rewrite.Method, fixtureFilename, wantFilename string) {

--- a/pkg/rewrite/testdata/README.md
+++ b/pkg/rewrite/testdata/README.md
@@ -1,0 +1,8 @@
+# errto/testdata
+
+This directory contains the test fixtures.
+
+- `basic/`
+- `full/`
+- `from_pkgerrors/`
+  - Test rewriting from pkg/errors to any.

--- a/pkg/rewrite/testdata/pkgerrors_specific/goerrors/main.go
+++ b/pkg/rewrite/testdata/pkgerrors_specific/goerrors/main.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"strconv"
+)
+
+func check1(s string) error {
+	if _, err := strconv.Atoi(s); err != nil {
+		return fmt.Errorf("%s: %w", "invalid number", err)
+	}
+	return nil
+}
+
+func check2(s string) error {
+	if _, err := strconv.Atoi(s); err != nil {
+		return fmt.Errorf("%w", err)
+	}
+	return nil
+}
+
+func check3(s string) error {
+	if _, err := strconv.Atoi(s); err != nil {
+		return fmt.Errorf("%s: %s", "invalid number", err)
+	}
+	return nil
+}
+
+func check4(s string) error {
+	if _, err := strconv.Atoi(s); err != nil {
+		return fmt.Errorf("invalid number: %s: %s", s, err)
+	}
+	return nil
+}
+
+// main is an entry point.
+func main() {
+	if len(os.Args) < 2 {
+		log.Fatalf("usage: %s NUMBER", os.Args[0])
+	}
+
+	log.Printf("err=%s", check1(os.Args[1]))
+	log.Printf("err=%s", check2(os.Args[1]))
+	log.Printf("err=%s", check3(os.Args[1]))
+	log.Printf("err=%s", check4(os.Args[1]))
+
+	log.Printf("stacktrace=\n%+v", check1(os.Args[1]))
+	log.Printf("stacktrace=\n%+v", check2(os.Args[1]))
+	log.Printf("stacktrace=\n%+v", check3(os.Args[1]))
+	log.Printf("stacktrace=\n%+v", check4(os.Args[1]))
+}

--- a/pkg/rewrite/testdata/pkgerrors_specific/pkgerrors/main.go
+++ b/pkg/rewrite/testdata/pkgerrors_specific/pkgerrors/main.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"github.com/pkg/errors"
+	"log"
+	"os"
+	"strconv"
+)
+
+func check1(s string) error {
+	if _, err := strconv.Atoi(s); err != nil {
+		return errors.Wrap(err, "invalid number")
+	}
+	return nil
+}
+
+func check2(s string) error {
+	if _, err := strconv.Atoi(s); err != nil {
+		return errors.WithStack(err)
+	}
+	return nil
+}
+
+func check3(s string) error {
+	if _, err := strconv.Atoi(s); err != nil {
+		return errors.WithMessage(err, "invalid number")
+	}
+	return nil
+}
+
+func check4(s string) error {
+	if _, err := strconv.Atoi(s); err != nil {
+		return errors.WithMessagef(err, "invalid number: %s", s)
+	}
+	return nil
+}
+
+// main is an entry point.
+func main() {
+	if len(os.Args) < 2 {
+		log.Fatalf("usage: %s NUMBER", os.Args[0])
+	}
+
+	log.Printf("err=%s", check1(os.Args[1]))
+	log.Printf("err=%s", check2(os.Args[1]))
+	log.Printf("err=%s", check3(os.Args[1]))
+	log.Printf("err=%s", check4(os.Args[1]))
+
+	log.Printf("stacktrace=\n%+v", check1(os.Args[1]))
+	log.Printf("stacktrace=\n%+v", check2(os.Args[1]))
+	log.Printf("stacktrace=\n%+v", check3(os.Args[1]))
+	log.Printf("stacktrace=\n%+v", check4(os.Args[1]))
+}

--- a/pkg/rewrite/testdata/pkgerrors_specific/xerrors/main.go
+++ b/pkg/rewrite/testdata/pkgerrors_specific/xerrors/main.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"golang.org/x/xerrors"
+	"log"
+	"os"
+	"strconv"
+)
+
+func check1(s string) error {
+	if _, err := strconv.Atoi(s); err != nil {
+		return xerrors.Errorf("%s: %w", "invalid number", err)
+	}
+	return nil
+}
+
+func check2(s string) error {
+	if _, err := strconv.Atoi(s); err != nil {
+		return xerrors.Errorf("%w", err)
+	}
+	return nil
+}
+
+func check3(s string) error {
+	if _, err := strconv.Atoi(s); err != nil {
+		return xerrors.Errorf("%s: %s", "invalid number", err)
+	}
+	return nil
+}
+
+func check4(s string) error {
+	if _, err := strconv.Atoi(s); err != nil {
+		return xerrors.Errorf("invalid number: %s: %s", s, err)
+	}
+	return nil
+}
+
+// main is an entry point.
+func main() {
+	if len(os.Args) < 2 {
+		log.Fatalf("usage: %s NUMBER", os.Args[0])
+	}
+
+	log.Printf("err=%s", check1(os.Args[1]))
+	log.Printf("err=%s", check2(os.Args[1]))
+	log.Printf("err=%s", check3(os.Args[1]))
+	log.Printf("err=%s", check4(os.Args[1]))
+
+	log.Printf("stacktrace=\n%+v", check1(os.Args[1]))
+	log.Printf("stacktrace=\n%+v", check2(os.Args[1]))
+	log.Printf("stacktrace=\n%+v", check3(os.Args[1]))
+	log.Printf("stacktrace=\n%+v", check4(os.Args[1]))
+}

--- a/pkg/rewrite/xerrors.go
+++ b/pkg/rewrite/xerrors.go
@@ -136,6 +136,76 @@ func (v *toXerrorsVisitor) pkgErrorsFunctionCall(p token.Position, call *ast.Cal
 		log.Printf("rewrite: %s: pkg/errors.Cause() -> xerrors.Unwrap()", p)
 		v.needImport++
 		return nil
+
+	case "Wrap":
+		pkg.Name = "xerrors"
+		fun.Sel.Name = "Errorf"
+		if len(call.Args) != 2 {
+			return xerrors.Errorf("pkg/errors.Wrap expects 2 arguments but has %d arguments", len(call.Args))
+		}
+		call.Args = []ast.Expr{
+			&ast.BasicLit{Value: `"%s: %w"`},
+			call.Args[1],
+			call.Args[0],
+		}
+		log.Printf("rewrite: %s: pkg/errors.Wrap() -> xerrors.Errorf()", p)
+		v.needImport++
+		return nil
+
+	case "WithStack":
+		pkg.Name = "xerrors"
+		fun.Sel.Name = "Errorf"
+		if len(call.Args) != 1 {
+			return xerrors.Errorf("pkg/errors.WithStack expects 1 argument but has %d arguments", len(call.Args))
+		}
+		call.Args = []ast.Expr{
+			&ast.BasicLit{Value: `"%w"`},
+			call.Args[0],
+		}
+		log.Printf("rewrite: %s: pkg/errors.WithStack() -> xerrors.Errorf()", p)
+		v.needImport++
+		return nil
+
+	case "WithMessage":
+		pkg.Name = "xerrors"
+		fun.Sel.Name = "Errorf"
+		if len(call.Args) != 2 {
+			return xerrors.Errorf("pkg/errors.WithMessage expects 2 arguments but has %d arguments", len(call.Args))
+		}
+		call.Args = []ast.Expr{
+			&ast.BasicLit{Value: `"%s: %s"`},
+			call.Args[1],
+			call.Args[0],
+		}
+		log.Printf("rewrite: %s: pkg/errors.WithMessage() -> xerrors.Errorf()", p)
+		v.needImport++
+		return nil
+
+	case "WithMessagef":
+		pkg.Name = "xerrors"
+		fun.Sel.Name = "Errorf"
+
+		// reorder the args
+		a := call.Args
+		args := make([]ast.Expr, 0)
+		args = append(args, a[1])
+		args = append(args, a[2:]...)
+		args = append(args, a[0])
+		call.Args = args
+
+		// append %s to the format arg
+		b, ok := a[1].(*ast.BasicLit)
+		if !ok {
+			return xerrors.Errorf("2nd argument of Wrapf must be a literal but %T", a[1])
+		}
+		if b.Kind != token.STRING {
+			return xerrors.Errorf("2nd argument of Wrapf must be a string but %s", b.Kind)
+		}
+		b.Value = strings.TrimSuffix(b.Value, `"`) + `: %s"`
+
+		log.Printf("rewrite: %s: pkg/errors.WithMessagef() -> xerrors.Errorf()", p)
+		v.needImport++
+		return nil
 	}
 
 	pkg.Name = "xerrors"


### PR DESCRIPTION
This will add support of the following rewrite rules:

- pkg/errors.Wrap
- pkg/errors.WithStack
- pkg/errors.WithMessage
- pkg/errors.WithMessagef