### PR TITLE
Fix warnings of unsupported functions in test

### DIFF
--- a/pkg/rewrite/goerrors.go
+++ b/pkg/rewrite/goerrors.go
@@ -99,7 +99,7 @@ func (v *toGoErrorsVisitor) pkgErrorsFunctionCall(call astio.PackageFunctionCall
 		v.needImportFmt++
 		return nil
 
-	case "New":
+	case "New", "Unwrap", "As", "Is":
 		replacePackageFunctionCall(call, "errors", "")
 		v.needImportErrors++
 		return nil

--- a/pkg/rewrite/xerrors.go
+++ b/pkg/rewrite/xerrors.go
@@ -117,7 +117,7 @@ func (v *toXerrorsVisitor) pkgErrorsFunctionCall(call astio.PackageFunctionCall)
 		v.needImport++
 		return nil
 
-	case "Errorf", "New":
+	case "Errorf", "New", "Unwrap", "As", "Is":
 		replacePackageFunctionCall(call, "xerrors", "")
 		v.needImport++
 		return nil


### PR DESCRIPTION
```
    xerrors.go:195: fixture966342290/main.go:35:33: NOTE: you need to manually rewrite errors.Unwrap()
    goerrors.go:177: fixture496201108/main.go:35:33: NOTE: you need to manually rewrite errors.Unwrap()
    goerrors.go:177: fixture606520826/main.go:28:2: NOTE: you need to manually rewrite errors.Unwrap()
    goerrors.go:177: fixture606520826/main.go:32:2: NOTE: you need to manually rewrite errors.As()
    goerrors.go:177: fixture606520826/main.go:35:2: NOTE: you need to manually rewrite errors.Is()
    xerrors.go:195: fixture739617742/main.go:28:2: NOTE: you need to manually rewrite errors.Unwrap()
    xerrors.go:195: fixture739617742/main.go:32:2: NOTE: you need to manually rewrite errors.As()
    xerrors.go:195: fixture739617742/main.go:35:2: NOTE: you need to manually rewrite errors.Is()
```